### PR TITLE
Fixes #1.

### DIFF
--- a/lib/er/crawler.rb
+++ b/lib/er/crawler.rb
@@ -133,9 +133,17 @@ module Er
     end
 
     def _store_er_items_user(user_id, item_id, page_url)
-      items_user_data = {user_id: user_id, item_id: item_id,
-                         wordbook_url: page_url}
-      return Er::ItemsUser.find_or_create_by(items_user_data)
+      u_items = Er::ItemsUser.where(user_id: user_id, item_id: item_id)
+      u_item = nil
+      if u_items.size == 0
+        u_item = Er::ItemsUser.create(user_id: user_id, item_id: item_id,
+                                      wordbook_url: page_url)
+      else
+        u_item = u_items.first
+        u_item.wordbook_url = page_url
+        u_item.save
+      end
+      return u_item
     end
 
     def _store_and_delete_er_items_users_tags(u_item_id, tag_name_ary,

--- a/spec/lib/er/crawler_invoker_spec.rb
+++ b/spec/lib/er/crawler_invoker_spec.rb
@@ -34,7 +34,7 @@ describe 'Er::CrawlerInvoker' do
       skip unless @config['fakeweb_enable']
       @sample_data['wordbook_pages'].keys.each do |p_index|
         expected = @sample_data['wordbook_pages'][p_index]['words_and_tags']
-        check_er_items(expected)
+        check_existence_of_er_items(expected)
       end
     end
 
@@ -42,7 +42,7 @@ describe 'Er::CrawlerInvoker' do
       # This spec can be done only when fakeweb_enabled is true
       skip unless @config['fakeweb_enable']
       _check_with_block do |user, url, expected|
-        check_er_items_users(user, url, expected)
+        check_existence_of_er_items_users(user, url, expected)
       end
     end
 
@@ -50,7 +50,8 @@ describe 'Er::CrawlerInvoker' do
       # This spec can be done only when fakeweb_enabled is true
       skip unless @config['fakeweb_enable']
       _check_with_block do |user, url, expected|
-        check_er_items_users_tags(user, url, expected, @scraping_time)
+        check_existence_of_er_items_users_tags(user, url, expected,
+                                               @scraping_time)
       end
     end
 

--- a/spec/lib/er/crawler_spec_helper.rb
+++ b/spec/lib/er/crawler_spec_helper.rb
@@ -7,7 +7,7 @@ module Er
       create(:test_tagdone)
     end
 
-    def check_er_items(expected_words_and_tags)
+    def check_existence_of_er_items(expected_words_and_tags)
       expect {
         expected_words_and_tags.each_key do |e_id|
           word = expected_words_and_tags[e_id]['word']
@@ -16,19 +16,31 @@ module Er
       }.not_to raise_error
     end
 
-    def check_er_items_users(user, page_url, expected_words_and_tags)
+    def check_existence_of_er_items_users(
+        user, page_url, expected_words_and_tags)
+      _check_er_items_users(true, user, page_url, expected_words_and_tags)
+    end
+
+    def check_absence_of_er_items_users(
+        user, page_url, expected_words_and_tags)
+      _check_er_items_users(false, user, page_url, expected_words_and_tags)
+    end
+
+    def _check_er_items_users(
+        bool, user, page_url, expected_words_and_tags)
       expect {
+        expected_num = bool ? 1 : 0
         expected_words_and_tags.each_key do |e_id|
           item = Er::Item.find_by_e_id(e_id)
           expect(Er::ItemsUser.where(user_id: user.id,
             item_id: item.id,
-            wordbook_url: page_url).size).to eq(1)
+            wordbook_url: page_url).size).to eq(expected_num)
         end
       }.not_to raise_error
     end
 
-    def check_er_items_users_tags(user, page_url, expected_words_and_tags,
-                                  registration_date)
+    def check_existence_of_er_items_users_tags(
+        user, page_url, expected_words_and_tags, registration_date)
       expect {
         expected_words_and_tags.each_key do |e_id|
           tags = expected_words_and_tags[e_id]['tags']


### PR DESCRIPTION
This fix includes:
  - Business logic change in storing er_items_user - deleting
    wordbook_url parameters when looking up entries and when an entry is
    found, update wordbook_url with the specified parameter.
  - Refactoring of method name like check_"existence_of"_...
  - Now "_register_words_and_tags" method in crawler_spec returns a hash
    which includes Er objects which were populated in db.